### PR TITLE
Fix arithmetic overflow on untrusted input

### DIFF
--- a/Sources/sqids/Sqids.swift
+++ b/Sources/sqids/Sqids.swift
@@ -217,7 +217,7 @@ public struct Sqids {
         let count = Id(alphabet.count)
         
         return id.reduce(0) {
-            $0 * count + Id(alphabet.firstIndex(of: $1) ?? -1)
+            $0 &* count &+ Id(alphabet.firstIndex(of: $1) ?? -1)
         }
     }
     

--- a/Tests/sqidsTests/EncodeTests.swift
+++ b/Tests/sqidsTests/EncodeTests.swift
@@ -149,6 +149,9 @@ final class EncodeTests: XCTestCase {
     func testDecodeOfUntrustedInput() throws {
         let sqids = Sqids()
         let badInput = try sqids.encode([Int64.max]) + "a"
-        _ = try sqids.decode(badInput) // Should not crash
+        do {
+            _ = try sqids.decode(badInput) // Should not crash
+        }
+        catch Sqids.Error.overflow { }
     }
 }

--- a/Tests/sqidsTests/EncodeTests.swift
+++ b/Tests/sqidsTests/EncodeTests.swift
@@ -145,4 +145,10 @@ final class EncodeTests: XCTestCase {
             XCTAssertEqual(-1, id)
         }
     }
+    
+    func testDecodeOfUntrustedInput() throws {
+        let sqids = Sqids()
+        let badInput = try sqids.encode([Int64.max]) + "a"
+        _ = try sqids.decode(badInput) // Should not crash
+    }
 }


### PR DESCRIPTION
I reported a [similar bug](https://github.com/malczak/hashids/issues/24) to the original hashIds repo (that was never addressed). I discovered this repo and decided to test the same issue and it also exists here.

In it's current state, you cannot safely decode arbitrary untrusted user input (Imagine a user mistyping a url - which is how I originally discovered this in my app telemetry). I added a test case to this PR to demonstrate the problem and validate the fix. Here is an example:

```swift

func testDecodeOfUntrustedInput() throws {
        let sqids = Sqids()
        let badInput = try sqids.encode([Int64.max]) + "a" // Some untrusted user input
        _ = try sqids.decode(badInput) // 💥 Crash
    }
    
```

By generating a squid of `Int64.max` and appending an `a` to it, you create an id that when decoded overflows an `Int64`. In swift, this will trigger an arithmetic overflow that will crash your program. It is impossible to validate a valid sqid before trying to decode it, so there is no valid way to sanitize user input which risks crashing your program. 

There are two ways to fix this:
1. allow overflow (such that the ID is decoded to an incorrect Int
2. throw an error when overflow is detected. 

This PR uses approach `2` because the decode function already throws, so it doesn't change the overall usability. (in the original hashids library, this required a bigger (api breaking change) because the original decode function did not throw. 

Solution `1` is also an option but will produce incorrect results. You can see that implementation in: https://github.com/sqids/sqids-swift/pull/2/commits/cc4be6178e153ea165b7bad0fa78b05fa36b7f07 
